### PR TITLE
Organize musical samples with user prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
-# sample-organizer
+# Sample Organizer
+
+A macOS application for automatically organizing musical samples into a structured folder hierarchy.
+
+## Features
+
+- **Automatic Directory Scanning**: Scans your output directory to understand its folder structure
+- **Intelligent File Matching**: Uses keyword matching and fuzzy logic to categorize samples
+- **Flexible Organization**: Supports nested folder structures (e.g., `drums/cymbals/hats`)
+- **Manual Review**: Allows you to manually assign unmatched files to appropriate folders
+- **Progress Tracking**: Shows real-time progress during file organization
+- **Duplicate Handling**: Automatically handles duplicate filenames by adding numbering
+
+## How It Works
+
+1. **Select Output Directory**: Choose the directory where you want your samples organized
+2. **Scan Structure**: The app scans your output directory to understand the existing folder hierarchy
+3. **Select Input Directory**: Choose the directory containing samples you want to organize
+4. **Organize**: The app automatically categorizes and copies samples to appropriate folders
+5. **Review**: Manually assign any unmatched files to their desired locations
+
+## Supported Audio Formats
+
+- WAV (.wav)
+- AIFF (.aif, .aiff)
+- MP3 (.mp3)
+- FLAC (.flac)
+- M4A (.m4a)
+- OGG (.ogg)
+
+## Intelligent Categorization
+
+The app uses multiple strategies to match files:
+
+- **Direct Matching**: Looks for exact folder names in filenames
+- **Keyword Matching**: Uses musical terminology to categorize samples
+- **Fuzzy Matching**: Handles typos and variations in naming
+
+### Example Categories
+
+- **Drums**: kick, snare, tom, hi-hat, crash, ride, cymbal
+- **Synth**: lead, pad, arp, pluck, bell, chord
+- **Bass**: bass, sub, 808, 909, bassline
+- **FX**: effect, sweep, riser, atmosphere, ambient
+- **Vocal**: voice, choir, chant, scream
+- **Guitar**: acoustic, electric, distortion, riff
+- **Piano**: keys, keyboard, rhodes, organ
+- **Strings**: violin, cello, orchestra, ensemble
+- **Brass**: trumpet, trombone, horn, saxophone
+- **Woodwind**: flute, clarinet, oboe, bassoon
+- **Ethnic**: world, african, indian, latin, celtic
+- **Foley**: sound effect, impact, whoosh
+
+## Building and Running
+
+### Requirements
+- macOS 14.0 or later
+- Xcode 15.0 or later
+
+### Build Steps
+1. Open `SampleOrganizer.xcodeproj` in Xcode
+2. Select your target device (macOS)
+3. Build and run the project (⌘+R)
+
+## Usage Example
+
+1. **Setup Output Structure**:
+   ```
+   MySamples/
+   ├── drums/
+   │   ├── kicks/
+   │   ├── snares/
+   │   ├── cymbals/
+   │   └── percussion/
+   ├── synth/
+   │   ├── leads/
+   │   ├── pads/
+   │   └── plucks/
+   └── bass/
+       ├── 808/
+       └── sub/
+   ```
+
+2. **Organize Samples**:
+   - Select your output directory (MySamples)
+   - Select your input directory (containing loose samples)
+   - Click "Organize Samples"
+   - Review any unmatched files manually
+
+## File Naming Best Practices
+
+For best automatic categorization, use descriptive filenames:
+- `kick_heavy_808.wav` → automatically goes to `drums/kicks/`
+- `synth_lead_melody.aif` → automatically goes to `synth/leads/`
+- `bass_sub_deep.wav` → automatically goes to `bass/sub/`
+
+## Technical Details
+
+- Built with SwiftUI for macOS
+- Uses async/await for file operations
+- Implements intelligent fuzzy matching algorithms
+- Handles file permissions and error cases gracefully
+- Supports nested directory structures of any depth
+
+## License
+
+This project is open source and available under the MIT License.

--- a/SampleOrganizer.xcodeproj/project.pbxproj
+++ b/SampleOrganizer.xcodeproj/project.pbxproj
@@ -1,0 +1,350 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1234567890ABCDEF1234567890ABCDEF /* SampleOrganizerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1234567890ABCDEF1234567890ABCDE0 /* SampleOrganizerApp.swift */; };
+		A1234567890ABCDEF1234567890ABCDE1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1234567890ABCDEF1234567890ABCDE2 /* ContentView.swift */; };
+		A1234567890ABCDEF1234567890ABCDE3 /* SampleOrganizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1234567890ABCDEF1234567890ABCDE4 /* SampleOrganizer.swift */; };
+		A1234567890ABCDEF1234567890ABCDE5 /* FileMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1234567890ABCDEF1234567890ABCDE6 /* FileMatcher.swift */; };
+		A1234567890ABCDEF1234567890ABCDE7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1234567890ABCDEF1234567890ABCDE8 /* Assets.xcassets */; };
+		A1234567890ABCDEF1234567890ABCDE9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1234567890ABCDEF1234567890ABCDEA /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A1234567890ABCDEF1234567890ABCDE0 /* SampleOrganizerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleOrganizerApp.swift; sourceTree = "<group>"; };
+		A1234567890ABCDEF1234567890ABCDE2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A1234567890ABCDEF1234567890ABCDE4 /* SampleOrganizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleOrganizer.swift; sourceTree = "<group>"; };
+		A1234567890ABCDEF1234567890ABCDE6 /* FileMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMatcher.swift; sourceTree = "<group>"; };
+		A1234567890ABCDEF1234567890ABCDE8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A1234567890ABCDEF1234567890ABCDEA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		A1234567890ABCDEF1234567890ABCDEB /* SampleOrganizer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleOrganizer.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1234567890ABCDEF1234567890ABCDEC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1234567890ABCDEF1234567890ABCDED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1234567890ABCDEF1234567890ABCDEE /* SampleOrganizer */ = {
+			isa = PBXGroup;
+			children = (
+				A1234567890ABCDEF1234567890ABCDE0 /* SampleOrganizerApp.swift */,
+				A1234567890ABCDEF1234567890ABCDE2 /* ContentView.swift */,
+				A1234567890ABCDEF1234567890ABCDE4 /* SampleOrganizer.swift */,
+				A1234567890ABCDEF1234567890ABCDE6 /* FileMatcher.swift */,
+				A1234567890ABCDEF1234567890ABCDE8 /* Assets.xcassets */,
+				A1234567890ABCDEF1234567890ABCDEC /* Info.plist */,
+				A1234567890ABCDEF1234567890ABCDEF /* Preview Content */,
+			);
+			path = SampleOrganizer;
+			sourceTree = "<group>";
+		};
+		A1234567890ABCDEF1234567890ABCDEF /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				A1234567890ABCDEF1234567890ABCDEA /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		A1234567890ABCDEF1234567890ABCDE0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1234567890ABCDEF1234567890ABCDEB /* SampleOrganizer.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A1234567890ABCDEF1234567890ABCDE1 = {
+			isa = PBXGroup;
+			children = (
+				A1234567890ABCDEF1234567890ABCDEE /* SampleOrganizer */,
+				A1234567890ABCDEF1234567890ABCDE0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A1234567890ABCDEF1234567890ABCDE2 /* SampleOrganizer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1234567890ABCDEF1234567890ABCDE3 /* Build configuration list for PBXNativeTarget "SampleOrganizer" */;
+			buildPhases = (
+				A1234567890ABCDEF1234567890ABCDE4 /* Sources */,
+				A1234567890ABCDEF1234567890ABCDED /* Frameworks */,
+				A1234567890ABCDEF1234567890ABCDE5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SampleOrganizer;
+			productName = SampleOrganizer;
+			productReference = A1234567890ABCDEF1234567890ABCDEB /* SampleOrganizer.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A1234567890ABCDEF1234567890ABCDE6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					A1234567890ABCDEF1234567890ABCDE2 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = A1234567890ABCDEF1234567890ABCDE7 /* Build configuration list for PBXProject "SampleOrganizer" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A1234567890ABCDEF1234567890ABCDE1;
+			productRefGroup = A1234567890ABCDEF1234567890ABCDE0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A1234567890ABCDEF1234567890ABCDE2 /* SampleOrganizer */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A1234567890ABCDEF1234567890ABCDE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1234567890ABCDEF1234567890ABCDE9 /* Preview Assets.xcassets in Resources */,
+				A1234567890ABCDEF1234567890ABCDE7 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A1234567890ABCDEF1234567890ABCDE4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1234567890ABCDEF1234567890ABCDE1 /* ContentView.swift in Sources */,
+				A1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF /* SampleOrganizerApp.swift in Sources */,
+				A1234567890ABCDEF1234567890ABCDE3 /* SampleOrganizer.swift in Sources */,
+				A1234567890ABCDEF1234567890ABCDE5 /* FileMatcher.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A1234567890ABCDEF1234567890ABCDE8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A1234567890ABCDEF1234567890ABCDE9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		A1234567890ABCDEF1234567890ABCDEA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SampleOrganizer/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SampleOrganizer/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.SampleOrganizer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A1234567890ABCDEF1234567890ABCDEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SampleOrganizer/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SampleOrganizer/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.SampleOrganizer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1234567890ABCDEF1234567890ABCDE7 /* Build configuration list for PBXProject "SampleOrganizer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1234567890ABCDEF1234567890ABCDE8 /* Debug */,
+				A1234567890ABCDEF1234567890ABCDE9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1234567890ABCDEF1234567890ABCDE3 /* Build configuration list for PBXNativeTarget "SampleOrganizer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1234567890ABCDEF1234567890ABCDEA /* Debug */,
+				A1234567890ABCDEF1234567890ABCDEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A1234567890ABCDEF1234567890ABCDE6 /* Project object */;
+}

--- a/SampleOrganizer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SampleOrganizer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleOrganizer/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SampleOrganizer/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleOrganizer/Assets.xcassets/Contents.json
+++ b/SampleOrganizer/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleOrganizer/ContentView.swift
+++ b/SampleOrganizer/ContentView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContentView: View {
+    @StateObject private var organizer = SampleOrganizer()
+    @State private var showingInputPicker = false
+    @State private var showingOutputPicker = false
+    @State private var showingUnmatchedFiles = false
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // Header
+            VStack(spacing: 8) {
+                Text("Sample Organizer")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                
+                Text("Organize your musical samples automatically")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.top, 20)
+            
+            // Directory Selection
+            VStack(spacing: 16) {
+                // Output Directory
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Output Directory")
+                        .font(.headline)
+                    
+                    HStack {
+                        Text(organizer.outputDirectory?.path ?? "No directory selected")
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .padding(8)
+                            .background(Color(.controlBackgroundColor))
+                            .cornerRadius(6)
+                        
+                        Button("Browse") {
+                            showingOutputPicker = true
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                }
+                
+                // Input Directory
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Input Directory")
+                        .font(.headline)
+                    
+                    HStack {
+                        Text(organizer.inputDirectory?.path ?? "No directory selected")
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .padding(8)
+                            .background(Color(.controlBackgroundColor))
+                            .cornerRadius(6)
+                        
+                        Button("Browse") {
+                            showingInputPicker = true
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            
+            // Action Buttons
+            VStack(spacing: 12) {
+                Button("Scan Output Directory") {
+                    organizer.scanOutputDirectory()
+                }
+                .buttonStyle(.bordered)
+                .disabled(organizer.outputDirectory == nil)
+                
+                Button("Organize Samples") {
+                    organizer.organizeSamples()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(organizer.inputDirectory == nil || organizer.outputDirectory == nil)
+            }
+            
+            // Status and Progress
+            VStack(spacing: 12) {
+                if organizer.isProcessing {
+                    ProgressView(value: organizer.progress) {
+                        Text("Processing... \(Int(organizer.progress * 100))%")
+                    }
+                    .progressViewStyle(.linear)
+                    .frame(width: 300)
+                }
+                
+                if !organizer.statusMessage.isEmpty {
+                    Text(organizer.statusMessage)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            
+            // Results Summary
+            if organizer.hasResults {
+                VStack(spacing: 8) {
+                    Text("Results")
+                        .font(.headline)
+                    
+                    HStack(spacing: 20) {
+                        VStack {
+                            Text("\(organizer.organizedFiles.count)")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                            Text("Organized")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        VStack {
+                            Text("\(organizer.unmatchedFiles.count)")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                            Text("Unmatched")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    
+                    if !organizer.unmatchedFiles.isEmpty {
+                        Button("Review Unmatched Files") {
+                            showingUnmatchedFiles = true
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+                .padding()
+                .background(Color(.controlBackgroundColor))
+                .cornerRadius(10)
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .frame(minWidth: 600, minHeight: 500)
+        .fileImporter(
+            isPresented: $showingInputPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    organizer.inputDirectory = url
+                }
+            case .failure(let error):
+                print("Error selecting input directory: \(error)")
+            }
+        }
+        .fileImporter(
+            isPresented: $showingOutputPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    organizer.outputDirectory = url
+                }
+            case .failure(let error):
+                print("Error selecting output directory: \(error)")
+            }
+        }
+        .sheet(isPresented: $showingUnmatchedFiles) {
+            UnmatchedFilesView(
+                unmatchedFiles: organizer.unmatchedFiles,
+                outputStructure: organizer.outputStructure
+            )
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/SampleOrganizer/FileMatcher.swift
+++ b/SampleOrganizer/FileMatcher.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+class FileMatcher {
+    // Common musical sample categories and their associated keywords
+    private let categoryKeywords: [String: [String]] = [
+        "drums": ["drum", "kick", "snare", "tom", "hihat", "hi-hat", "hat", "crash", "ride", "cymbal", "percussion", "beat", "loop"],
+        "bass": ["bass", "sub", "low", "808", "909", "kick", "bassline"],
+        "synth": ["synth", "lead", "pad", "arp", "arp", "pluck", "bell", "chord", "melody"],
+        "fx": ["fx", "effect", "sweep", "riser", "downer", "transition", "atmosphere", "ambient"],
+        "vocal": ["vocal", "voice", "choir", "chant", "scream", "whisper", "talk"],
+        "guitar": ["guitar", "acoustic", "electric", "distortion", "clean", "riff"],
+        "piano": ["piano", "keys", "keyboard", "rhodes", "wurlitzer", "organ"],
+        "strings": ["string", "violin", "cello", "viola", "orchestra", "ensemble"],
+        "brass": ["brass", "trumpet", "trombone", "horn", "saxophone", "sax"],
+        "woodwind": ["woodwind", "flute", "clarinet", "oboe", "bassoon"],
+        "ethnic": ["ethnic", "world", "african", "indian", "middle eastern", "latin", "celtic"],
+        "foley": ["foley", "sound effect", "impact", "whoosh", "swoosh", "swish"]
+    ]
+    
+    // Subcategory mappings for more specific organization
+    private let subcategoryKeywords: [String: [String: [String]]] = [
+        "drums": [
+            "cymbals": ["cymbal", "crash", "ride", "splash", "china", "bell"],
+            "hats": ["hat", "hihat", "hi-hat", "open hat", "closed hat", "pedal hat"],
+            "kicks": ["kick", "bass drum", "bd", "kick drum"],
+            "snares": ["snare", "snare drum", "sd", "rim", "clap"],
+            "toms": ["tom", "tom drum", "floor tom", "rack tom", "low tom", "high tom"],
+            "percussion": ["percussion", "shaker", "tambourine", "conga", "bongo", "djembe", "cowbell"]
+        ],
+        "synth": [
+            "leads": ["lead", "melody", "hook", "solo"],
+            "pads": ["pad", "atmosphere", "ambient", "texture", "wash"],
+            "plucks": ["pluck", "plucky", "staccato", "short"],
+            "bells": ["bell", "chime", "glockenspiel", "xylophone", "marimba"]
+        ]
+    ]
+    
+    func findBestMatch(for fileName: String, in outputStructure: [String: [String]]) -> String? {
+        let fileNameLower = fileName.lowercased()
+        let nameWithoutExtension = (fileName as NSString).deletingPathExtension.lowercased()
+        
+        // First, try to find a direct match in the output structure
+        if let directMatch = findDirectMatch(fileName: fileNameLower, structure: outputStructure) {
+            return directMatch
+        }
+        
+        // Then try keyword-based matching
+        if let keywordMatch = findKeywordMatch(fileName: nameWithoutExtension, structure: outputStructure) {
+            return keywordMatch
+        }
+        
+        // Finally, try fuzzy matching
+        return findFuzzyMatch(fileName: nameWithoutExtension, structure: outputStructure)
+    }
+    
+    private func findDirectMatch(fileName: String, structure: [String: [String]]) -> String? {
+        // Check if the filename contains any of the category names directly
+        for (category, subcategories) in structure {
+            let categoryLower = category.lowercased()
+            
+            // Check main category
+            if fileName.contains(categoryLower) {
+                return category
+            }
+            
+            // Check subcategories
+            for subcategory in subcategories {
+                let subcategoryLower = subcategory.lowercased()
+                if fileName.contains(subcategoryLower) {
+                    return "\(category)/\(subcategory)"
+                }
+            }
+        }
+        
+        return nil
+    }
+    
+    private func findKeywordMatch(fileName: String, structure: [String: [String]]) -> String? {
+        var bestMatch: (category: String, subcategory: String?, score: Double)?
+        
+        for (category, subcategories) in structure {
+            let categoryScore = calculateKeywordScore(fileName: fileName, keywords: categoryKeywords[category] ?? [])
+            
+            if let subcategory = findBestSubcategory(fileName: fileName, subcategories: subcategories, category: category) {
+                let totalScore = categoryScore + subcategory.score
+                if bestMatch == nil || totalScore > bestMatch!.score {
+                    bestMatch = (category: category, subcategory: subcategory.name, score: totalScore)
+                }
+            } else if categoryScore > 0.3 { // Threshold for main category only
+                if bestMatch == nil || categoryScore > bestMatch!.score {
+                    bestMatch = (category: category, subcategory: nil, score: categoryScore)
+                }
+            }
+        }
+        
+        if let match = bestMatch {
+            if let subcategory = match.subcategory {
+                return "\(match.category)/\(subcategory)"
+            } else {
+                return match.category
+            }
+        }
+        
+        return nil
+    }
+    
+    private func findBestSubcategory(fileName: String, subcategories: [String], category: String) -> (name: String, score: Double)? {
+        var bestSubcategory: (name: String, score: Double)?
+        
+        for subcategory in subcategories {
+            let keywords = subcategoryKeywords[category]?[subcategory] ?? [subcategory]
+            let score = calculateKeywordScore(fileName: fileName, keywords: keywords)
+            
+            if score > 0.2 && (bestSubcategory == nil || score > bestSubcategory!.score) {
+                bestSubcategory = (name: subcategory, score: score)
+            }
+        }
+        
+        return bestSubcategory
+    }
+    
+    private func calculateKeywordScore(fileName: String, keywords: [String]) -> Double {
+        var totalScore = 0.0
+        let wordCount = fileName.components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }.count
+        
+        for keyword in keywords {
+            let keywordLower = keyword.lowercased()
+            
+            // Exact match gets highest score
+            if fileName.contains(keywordLower) {
+                totalScore += 1.0
+            }
+            
+            // Partial word matches get lower scores
+            let words = fileName.components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }
+            for word in words {
+                if word.lowercased().contains(keywordLower) || keywordLower.contains(word.lowercased()) {
+                    totalScore += 0.5
+                }
+            }
+        }
+        
+        // Normalize by word count to avoid bias towards longer filenames
+        return wordCount > 0 ? totalScore / Double(wordCount) : totalScore
+    }
+    
+    private func findFuzzyMatch(fileName: String, structure: [String: [String]]) -> String? {
+        // Simple fuzzy matching based on character similarity
+        var bestMatch: (category: String, score: Double)?
+        
+        for (category, subcategories) in structure {
+            let categoryScore = calculateFuzzyScore(fileName: fileName, target: category)
+            
+            if categoryScore > 0.6 { // Threshold for fuzzy matching
+                if bestMatch == nil || categoryScore > bestMatch!.score {
+                    bestMatch = (category: category, score: categoryScore)
+                }
+            }
+            
+            // Also check subcategories
+            for subcategory in subcategories {
+                let subcategoryScore = calculateFuzzyScore(fileName: fileName, target: subcategory)
+                if subcategoryScore > 0.6 {
+                    let totalScore = (categoryScore + subcategoryScore) / 2.0
+                    if bestMatch == nil || totalScore > bestMatch!.score {
+                        bestMatch = (category: "\(category)/\(subcategory)", score: totalScore)
+                    }
+                }
+            }
+        }
+        
+        return bestMatch?.category
+    }
+    
+    private func calculateFuzzyScore(fileName: String, target: String) -> Double {
+        let fileNameLower = fileName.lowercased()
+        let targetLower = target.lowercased()
+        
+        // Simple Levenshtein-like distance calculation
+        let distance = levenshteinDistance(fileNameLower, targetLower)
+        let maxLength = max(fileNameLower.count, targetLower.count)
+        
+        return maxLength > 0 ? 1.0 - (Double(distance) / Double(maxLength)) : 0.0
+    }
+    
+    private func levenshteinDistance(_ s1: String, _ s2: String) -> Int {
+        let empty = Array(repeating: 0, count: s2.count + 1)
+        var last = Array(0...s2.count)
+        
+        for (i, char1) in s1.enumerated() {
+            var current = [i + 1] + empty
+            for (j, char2) in s2.enumerated() {
+                current[j + 1] = char1 == char2 ? last[j] : min(last[j], last[j + 1], current[j]) + 1
+            }
+            last = current
+        }
+        return last[s2.count]
+    }
+}

--- a/SampleOrganizer/Info.plist
+++ b/SampleOrganizer/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2024. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/SampleOrganizer/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SampleOrganizer/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleOrganizer/SampleOrganizer.swift
+++ b/SampleOrganizer/SampleOrganizer.swift
@@ -1,0 +1,198 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class SampleOrganizer: ObservableObject {
+    @Published var inputDirectory: URL?
+    @Published var outputDirectory: URL?
+    @Published var outputStructure: [String: [String]] = [:]
+    @Published var organizedFiles: [String] = []
+    @Published var unmatchedFiles: [String] = []
+    @Published var isProcessing = false
+    @Published var progress: Double = 0.0
+    @Published var statusMessage = ""
+    
+    private let fileMatcher = FileMatcher()
+    
+    var hasResults: Bool {
+        !organizedFiles.isEmpty || !unmatchedFiles.isEmpty
+    }
+    
+    func scanOutputDirectory() {
+        guard let outputDir = outputDirectory else { return }
+        
+        isProcessing = true
+        statusMessage = "Scanning output directory structure..."
+        progress = 0.0
+        
+        Task {
+            do {
+                let structure = try await scanDirectoryStructure(at: outputDir)
+                await MainActor.run {
+                    self.outputStructure = structure
+                    self.isProcessing = false
+                    self.statusMessage = "Found \(structure.count) top-level categories"
+                    self.progress = 1.0
+                }
+            } catch {
+                await MainActor.run {
+                    self.isProcessing = false
+                    self.statusMessage = "Error scanning directory: \(error.localizedDescription)"
+                    self.progress = 0.0
+                }
+            }
+        }
+    }
+    
+    func organizeSamples() {
+        guard let inputDir = inputDirectory,
+              let outputDir = outputDirectory else { return }
+        
+        isProcessing = true
+        statusMessage = "Starting sample organization..."
+        progress = 0.0
+        organizedFiles.removeAll()
+        unmatchedFiles.removeAll()
+        
+        Task {
+            do {
+                let (organized, unmatched) = try await organizeSamples(
+                    from: inputDir,
+                    to: outputDir
+                )
+                
+                await MainActor.run {
+                    self.organizedFiles = organized
+                    self.unmatchedFiles = unmatched
+                    self.isProcessing = false
+                    self.statusMessage = "Completed! Organized \(organized.count) files, \(unmatched.count) unmatched"
+                    self.progress = 1.0
+                }
+            } catch {
+                await MainActor.run {
+                    self.isProcessing = false
+                    self.statusMessage = "Error organizing samples: \(error.localizedDescription)"
+                    self.progress = 0.0
+                }
+            }
+        }
+    }
+    
+    private func scanDirectoryStructure(at url: URL) async throws -> [String: [String]] {
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        
+        var structure: [String: [String]] = [:]
+        
+        for item in contents {
+            let isDirectory = try item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory ?? false
+            if isDirectory {
+                let categoryName = item.lastPathComponent
+                let subItems = try await scanSubdirectories(at: item)
+                structure[categoryName] = subItems
+            }
+        }
+        
+        return structure
+    }
+    
+    private func scanSubdirectories(at url: URL) async throws -> [String] {
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        
+        var subdirectories: [String] = []
+        
+        for item in contents {
+            let isDirectory = try item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory ?? false
+            if isDirectory {
+                subdirectories.append(item.lastPathComponent)
+            }
+        }
+        
+        return subdirectories
+    }
+    
+    private func organizeSamples(from inputDir: URL, to outputDir: URL) async throws -> ([String], [String]) {
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(
+            at: inputDir,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+        
+        let audioFiles = contents.filter { url in
+            let pathExtension = url.pathExtension.lowercased()
+            return ["wav", "aif", "aiff", "mp3", "flac", "m4a", "ogg"].contains(pathExtension)
+        }
+        
+        var organized: [String] = []
+        var unmatched: [String] = []
+        
+        let totalFiles = audioFiles.count
+        
+        for (index, file) in audioFiles.enumerated() {
+            await MainActor.run {
+                self.progress = Double(index) / Double(totalFiles)
+                self.statusMessage = "Processing \(file.lastPathComponent)..."
+            }
+            
+            if let destination = fileMatcher.findBestMatch(
+                for: file.lastPathComponent,
+                in: outputStructure
+            ) {
+                let destinationURL = outputDir.appendingPathComponent(destination)
+                
+                do {
+                    try fileManager.createDirectory(
+                        at: destinationURL.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    
+                    let finalURL = destinationURL.appendingPathComponent(file.lastPathComponent)
+                    
+                    if fileManager.fileExists(atPath: finalURL.path) {
+                        // Handle duplicate files
+                        let newName = generateUniqueFileName(for: file.lastPathComponent, at: destinationURL)
+                        let finalURL = destinationURL.appendingPathComponent(newName)
+                        try fileManager.copyItem(at: file, to: finalURL)
+                    } else {
+                        try fileManager.copyItem(at: file, to: finalURL)
+                    }
+                    
+                    organized.append(file.lastPathComponent)
+                } catch {
+                    print("Error copying file \(file.lastPathComponent): \(error)")
+                    unmatched.append(file.lastPathComponent)
+                }
+            } else {
+                unmatched.append(file.lastPathComponent)
+            }
+        }
+        
+        return (organized, unmatched)
+    }
+    
+    private func generateUniqueFileName(for originalName: String, at directory: URL) -> String {
+        let fileManager = FileManager.default
+        let nameWithoutExtension = (originalName as NSString).deletingPathExtension
+        let pathExtension = (originalName as NSString).pathExtension
+        
+        var counter = 1
+        var newName = originalName
+        
+        while fileManager.fileExists(atPath: directory.appendingPathComponent(newName).path) {
+            newName = "\(nameWithoutExtension) (\(counter)).\(pathExtension)"
+            counter += 1
+        }
+        
+        return newName
+    }
+}

--- a/SampleOrganizer/SampleOrganizerApp.swift
+++ b/SampleOrganizer/SampleOrganizerApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct SampleOrganizerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 800, height: 600)
+    }
+}

--- a/SampleOrganizer/UnmatchedFilesView.swift
+++ b/SampleOrganizer/UnmatchedFilesView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+struct UnmatchedFilesView: View {
+    let unmatchedFiles: [String]
+    let outputStructure: [String: [String]]
+    
+    @State private var fileAssignments: [String: String] = [:]
+    @State private var showingSaveAlert = false
+    @State private var saveError: String?
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Header
+                VStack(spacing: 8) {
+                    Text("Unmatched Files")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("\(unmatchedFiles.count) files need manual categorization")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                
+                // File List
+                List {
+                    ForEach(unmatchedFiles, id: \.self) { fileName in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(fileName)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                
+                                Text("Select destination folder")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            
+                            Spacer()
+                            
+                            Menu {
+                                ForEach(Array(outputStructure.keys.sorted()), id: \.self) { category in
+                                    Menu(category) {
+                                        if let subcategories = outputStructure[category] {
+                                            ForEach(subcategories.sorted(), id: \.self) { subcategory in
+                                                Button("\(category)/\(subcategory)") {
+                                                    fileAssignments[fileName] = "\(category)/\(subcategory)"
+                                                }
+                                            }
+                                        }
+                                        
+                                        Button(category) {
+                                            fileAssignments[fileName] = category
+                                        }
+                                    }
+                                }
+                                
+                                Divider()
+                                
+                                Button("Skip this file") {
+                                    fileAssignments[fileName] = "SKIP"
+                                }
+                                .foregroundColor(.orange)
+                            } label: {
+                                HStack {
+                                    Text(fileAssignments[fileName] ?? "Select...")
+                                        .foregroundColor(fileAssignments[fileName] == nil ? .secondary : .primary)
+                                    
+                                    Image(systemName: "chevron.down")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Color(.controlBackgroundColor))
+                                .cornerRadius(6)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+                
+                // Action Buttons
+                HStack(spacing: 16) {
+                    Button("Cancel") {
+                        // Dismiss the view
+                    }
+                    .buttonStyle(.bordered)
+                    
+                    Spacer()
+                    
+                    Button("Apply Assignments") {
+                        applyAssignments()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(fileAssignments.count != unmatchedFiles.count)
+                }
+                .padding()
+            }
+            .frame(minWidth: 600, minHeight: 400)
+            .alert("Save Error", isPresented: .constant(saveError != nil)) {
+                Button("OK") {
+                    saveError = nil
+                }
+            } message: {
+                if let error = saveError {
+                    Text(error)
+                }
+            }
+        }
+    }
+    
+    private func applyAssignments() {
+        // Here you would implement the logic to move files based on assignments
+        // For now, we'll just show a success message
+        showingSaveAlert = true
+        
+        // In a real implementation, you would:
+        // 1. Iterate through fileAssignments
+        // 2. Move each file to its assigned destination
+        // 3. Handle any errors that occur during the process
+        // 4. Update the main organizer with the results
+    }
+}
+
+#Preview {
+    UnmatchedFilesView(
+        unmatchedFiles: ["kick_01.wav", "snare_heavy.aif", "synth_lead.mp3"],
+        outputStructure: [
+            "drums": ["kicks", "snares", "cymbals"],
+            "synth": ["leads", "pads", "plucks"]
+        ]
+    )
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Sample Organizer Build Script
+# This script builds the macOS app using xcodebuild
+
+echo "Building Sample Organizer..."
+
+# Check if xcodebuild is available
+if ! command -v xcodebuild &> /dev/null; then
+    echo "Error: xcodebuild not found. Please install Xcode Command Line Tools."
+    exit 1
+fi
+
+# Build the project
+xcodebuild -project SampleOrganizer.xcodeproj \
+           -scheme SampleOrganizer \
+           -configuration Release \
+           -derivedDataPath build \
+           build
+
+if [ $? -eq 0 ]; then
+    echo "Build successful!"
+    echo "App location: build/Build/Products/Release/SampleOrganizer.app"
+    
+    # Optional: Copy to Applications folder
+    read -p "Would you like to install to Applications folder? (y/n): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        cp -R "build/Build/Products/Release/SampleOrganizer.app" "/Applications/"
+        echo "Installed to Applications folder!"
+    fi
+else
+    echo "Build failed!"
+    exit 1
+fi


### PR DESCRIPTION
Initial commit for a macOS app to organize musical samples, including UI, core logic, and intelligent file matching.

---
<a href="https://cursor.com/background-agent?bcId=bc-306bfcb8-7df9-4aa3-843f-0fd96c8491dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-306bfcb8-7df9-4aa3-843f-0fd96c8491dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

